### PR TITLE
0.12.12.11.16440 Builds [ 16440 ]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ There is a separate author. Please check the license.
 
 ## Requirements
 
-- Escape From Tarkov 0.12.12
+- Escape From Tarkov 0.12.12.11.16440
 - Visual Studio Build Tools (.NET desktop workload)
 - .NET 5.0.10

--- a/project/Aki.Launcher.Base/Controllers/LogManager.cs
+++ b/project/Aki.Launcher.Base/Controllers/LogManager.cs
@@ -23,7 +23,7 @@ namespace Aki.Launcher.Controllers
 
         public LogManager()
         {
-            filepath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Logs");
+            filepath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "user", "logs");
         }
 
         public void Write(string text)
@@ -33,8 +33,8 @@ namespace Aki.Launcher.Controllers
                 Directory.CreateDirectory(filepath);
             }
 
-            string filename = Path.Combine(filepath, $"{DateTime.Now:yyyyMMdd}.log");
-            File.AppendAllLines(filename, new[] { $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}]{text}" });
+            string filename = Path.Combine(filepath, "launcher.log");
+            File.WriteAllLines(filename, new[] { $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}]{text}" });
         }
 
         public void Debug(string text) => Write($"[Debug]{text}");

--- a/project/Aki.Launcher.Base/Helpers/LauncherSettingsProvider.cs
+++ b/project/Aki.Launcher.Base/Helpers/LauncherSettingsProvider.cs
@@ -139,7 +139,22 @@ namespace Aki.Launcher.Helpers
                 }
             }
         }
-        
+
+        private string[] _ExcludeFromCleanup;
+
+        public string[] ExcludeFromCleanup
+        {
+            get => _ExcludeFromCleanup ??= Array.Empty<string>();
+            set
+            {
+                if (_ExcludeFromCleanup != value)
+                {
+                    _ExcludeFromCleanup = value;
+                    RaisePropertyChanged(nameof(ExcludeFromCleanup));
+                }
+            }
+        }
+
         private static string DetectOriginalGamePath()
         {
             // We can't detect the installed path on non-Windows

--- a/project/Aki.Launcher/Aki_Data/Launcher/Locales/English.json
+++ b/project/Aki.Launcher/Aki_Data/Launcher/Locales/English.json
@@ -30,7 +30,7 @@
     "account_exist": "Account already exists",
     "url": "URL",
     "default_language": "Default Language",
-    "game_path": "SPT Game Path",
+    "game_path": "Game Path",
     "clear_game_settings": "Clear Game Settings",
     "clear_game_settings_warning": "You are about to remove your old game settings files. They will be backed up to:\n{0}\n\nAre you sure?",
     "clear_game_settings_succeeded": "Game settings cleared.",


### PR DESCRIPTION
- update bpf
1. File Cleanup Exclusion Setting
- Adds a new setting to the config file that allows certain files and folders to be excluded from file cleanup. Initializes to an empty string array by default. Files that skip cleanup are printed in the logfile.
- Added a setting field in the config that allows certain files or folders to be excluded from cleanup
- Fixed launcher logs being deleted on game start; Updated logfile name; Changed logging from append mode to overwrite mode 